### PR TITLE
Add "aborted" error type

### DIFF
--- a/src/jquery.jsonp.js
+++ b/src/jquery.jsonp.js
@@ -41,6 +41,7 @@
 		STR_CHARSET = "charset",
 		STR_EMPTY = "",
 		STR_ERROR = "error",
+		STR_ABORTED = "aborted",
 		STR_INSERT_BEFORE = "insertBefore",
 		STR_JQUERY_JSONP = "_jqjsp",
 		STR_ON = "on",
@@ -138,7 +139,7 @@
 
 		// Create the abort method
 		xOptions.abort = function() {
-			!( done++ ) && cleanUp();
+			notifyError( STR_ABORTED );
 		};
 
 		// Call beforeSend if provided (early abort if false returned)
@@ -187,7 +188,7 @@
 				// Clean up
 				cleanUp();
 				// If pure error (not timeout), cache if needed
-				pageCacheFlag && type != STR_TIMEOUT && ( pageCache[ url ] = type );
+				pageCacheFlag && type == STR_ERROR && ( pageCache[ url ] = type );
 				// Call error then complete
 				callIfDefined( errorCallback , xOptions , [ xOptions , type ] );
 				callIfDefined( completeCallback , xOptions , [ xOptions , type ] );


### PR DESCRIPTION
Hello, I found it useful while using your library that the success() callback would be called event after an explicit abort, in order to clean app the rest of the application.
