### PR TITLE
Changing cache busting to use jQuery convention.

### DIFF
--- a/src/jquery.jsonp.js
+++ b/src/jquery.jsonp.js
@@ -154,7 +154,7 @@
 		callbackParameter && ( url += qMarkOrAmp( url ) + encodeURIComponent( callbackParameter ) + "=?" );
 
 		// Add anticache parameter if needed
-		!cacheFlag && !pageCacheFlag && ( url += qMarkOrAmp( url ) + "_" + ( new Date() ).getTime() + "=" );
+		!cacheFlag && !pageCacheFlag && ( url += qMarkOrAmp( url ) + "_=" + ( new Date() ).getTime() );
 
 		// Replace last ? by callback parameter
 		url = url.replace( /=\?(&|$)/ , "=" + successCallbackName + "$1" );


### PR DESCRIPTION
This simple commit changes the cache busting mechanism to use _=TIMESTAMP instead of _TIMESTAMP= as this is what jQuery uses.

https://github.com/jquery/jquery/blob/master/src/ajax.js#L628

It is also more helpful to handle this on the server side caching.
