### PR TITLE
FIX callback desync rare bug, assign easch script's data to a new member...

### DIFF
--- a/src/jquery.jsonp.js
+++ b/src/jquery.jsonp.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery JSONP Core Plugin 2.4.0 (2012-08-21)
  *
  * https://github.com/jaubourg/jquery-jsonp
@@ -17,8 +17,10 @@
 	}
 
 	// Generic callback
-	function genericCallback( data ) {
-		lastValue = [ data ];
+	function getGenericCallback(id) {
+		return function genericCallback( data ) {
+			lastValues[id] = [ data ];
+		}
 	}
 
 	// Call if defined
@@ -60,7 +62,7 @@
 		// Counter
 		count = 0,
 		// Last returned value
-		lastValue,
+		lastValues = {},
 
 		// ###################### DEFAULT OPTIONS ##
 		xOptionsDefaults = {
@@ -107,6 +109,7 @@
 			data = xOptions.data,
 			timeout = xOptions.timeout,
 			pageCached,
+			thisId,
 
 			// Abort/done flag
 			done = 0,
@@ -201,11 +204,11 @@
 
 			// Install the generic callback
 			// (BEWARE: global namespace pollution ahoy)
-			win[ successCallbackName ] = genericCallback;
+			win[ successCallbackName ] = getGenericCallback(thisId = count++);
 
 			// Create the script tag
 			script = $( STR_SCRIPT_TAG )[ 0 ];
-			script.id = STR_JQUERY_JSONP + count++;
+			script.id = STR_JQUERY_JSONP + thisId;
 
 			// Set charset if provided
 			if ( charset ) {
@@ -240,8 +243,9 @@
 
 					} catch( _ ) {}
 
-					result = lastValue;
-					lastValue = 0;
+					result = lastValues[thisId];
+					delete lastValues[thisId];
+					// win[ successCallbackName ] = null;
 					result ? notifySuccess( result[ 0 ] ) : notifyError( STR_ERROR );
 
 				}


### PR DESCRIPTION
... record on lastValues hash

This bug can be manifested when a pending fetch is aborted and right afterwards a new fetch that
leads to error (e.g. 404) is issued. At the time, the second request finishes the lastValue has
the aborted data of the previous fetch, YIELDING the second (erroneus response) to be signaled
as successfull.
