### PR TITLE
Support for loading as an AMD module

### DIFF
--- a/src/jquery.jsonp.js
+++ b/src/jquery.jsonp.js
@@ -19,7 +19,7 @@
     /* Define using browser globals otherwise
      * Prevent multiple instantiations if the script is loaded twice
      */
-    else if ( jQuery && !jQuery.fn.jsonp )
+    else if ( jQuery && !jQuery.jsonp )
     {
         factory( jQuery );
     }
@@ -296,6 +296,6 @@
 	};
 
 	// ###################### INSTALL in jQuery ##
-	$.fn.jsonp = jsonp;
+	$.jsonp = jsonp;
 
 }));


### PR DESCRIPTION
Allow the plugin to be loaded as an AMD module.  For more details, see:
http://requirejs.org/docs/whyamd.html

As a side effect, this prevents things from being instantiated multiple times if the script is included more than once on the page.
