### PR TITLE
Use as an AMD module

### DIFF
--- a/src/jquery.jsonp.js
+++ b/src/jquery.jsonp.js
@@ -290,5 +290,6 @@
 
 	// ###################### INSTALL in jQuery ##
 	$.jsonp = jsonp;
+        return jsonp;
 
 }));


### PR DESCRIPTION
This PR wraps jquery-jsonp with a definition that works both with a global jQuery object and in an AMD environment.
It's fully backward-compatible.

When used as an AMD module, it returns the `jsonp` function that can be accessed directly. No need to access it as a property of the `jQuery` object.
